### PR TITLE
work with python3

### DIFF
--- a/buildAndPackageOpenCV.sh
+++ b/buildAndPackageOpenCV.sh
@@ -220,7 +220,7 @@ fi
 
 
 # check installation
-IMPORT_CHECK="$(python -c "import cv2 ; print cv2.__version__")"
+IMPORT_CHECK="$(python -c "import cv2 ; print(cv2.__version__)")"
 if [[ $IMPORT_CHECK != *$OPENCV_VERSION* ]]; then
   echo "There was an error loading OpenCV in the Python sanity test."
   echo "The loaded version does not match the version built here."

--- a/buildOpenCV.sh
+++ b/buildOpenCV.sh
@@ -194,7 +194,7 @@ else
 fi
 
 # check installation
-IMPORT_CHECK="$(python -c "import cv2 ; print cv2.__version__")"
+IMPORT_CHECK="$(python -c "import cv2 ; print(cv2.__version__)")"
 if [[ $IMPORT_CHECK != *$OPENCV_VERSION* ]]; then
   echo "There was an error loading OpenCV in the Python sanity test."
   echo "The loaded version does not match the version built here."


### PR DESCRIPTION
I had a setup where python3 was default interpretor. Script worked like magic until the end. 

=> Making script work even if there is python 3 by default (python 2 can manage print with parenthesis, python 3 cant without parenthesis)